### PR TITLE
Dp current user posts

### DIFF
--- a/src/managers/PostManager.js
+++ b/src/managers/PostManager.js
@@ -49,7 +49,7 @@ export const getSinglePost = (id) => {
 }
 
 export const getCurrentUsersPosts = () => {
-  return fetch(`http://localhost:8000/posts?user_id=${localStorage.getItem('auth_token')}`, {
+  return fetch(`http://localhost:8000/posts?author=${parseInt(localStorage.getItem('user_id'))}`, {
     headers: {
       'Authorization': `Token ${localStorage.getItem('auth_token')}`
     }


### PR DESCRIPTION
Updated client and server side to handle filtering by currently logged in user.

TO TEST:

On BOTH client and server side, please do the following. 
- [ ] git fetch --all
- [ ] git checkout DP-current-user-posts (same branch name for both sides)
- [ ] verify you have at least 2 posts and 2 authors (users) in your DB. If you don't have two users, please register a new one via client. If you don't have two posts, run the posts fixture in terminal. (python3 manage.py loaddata posts)
- [ ] run the server (python3 manage.py runserver)
- [ ] run the client (npm start)
- [ ] make sure you're logged in as either user 1 or user 2
- [ ] select "My Posts"
- [ ]  verify that only the post(s) for the currently logged in user are displayed.
- [ ]  if successful, do a fun celebratory dance